### PR TITLE
Update Kate Hoey's screen name.

### DIFF
--- a/mps.txt
+++ b/mps.txt
@@ -250,7 +250,7 @@ Karen Buck @KarenBuckMP
 Karl McCartneyVerified account @karlmccartney
 Karl Turner MP @KarlTurnerMP
 Kate GreenVerified account @KateGreenSU
-Kate Hoey MPVerified account @hoeykateMP
+Kate Hoey MPVerified account @KateHoeyMP
 Katy Clark @KatyClarkMP
 Keith Vaz MP @Keith_VazMP
 Kerry McCarthy MP @KerryMP

--- a/screenamesOnly.txt
+++ b/screenamesOnly.txt
@@ -183,6 +183,7 @@
 @KarenBuckMP
 @KarlTurnerMP
 @KateGreenSU
+@KateHoeyMP
 @KatyClarkMP
 @KeeleyMP
 @Keith_VazMP
@@ -371,7 +372,6 @@
 @hammersmithandy
 @heidi_mp
 @hilarybennmp
-@hoeykateMP
 @iainastewart
 @iswales
 @jameswhartonmp


### PR DESCRIPTION
Kate Hoey has moved from @hoeykateMP to @KateHoeyMP.

The bio at the old screen name  points visitors to the new screen name, which now has the verified sticker. [https://twitter.com/KateHoeyMP]
